### PR TITLE
Fixes #4: Sepia Checkbox Behaviour

### DIFF
--- a/assets/js/photo-editor.js
+++ b/assets/js/photo-editor.js
@@ -227,6 +227,10 @@ function changeImageSepia(sepia) {
   if (sepia) {
     global_sepia = 1;
   }
+  else {
+    global_sepia = 0;
+  }
+  
   UpdateImageFilter();
 }
 


### PR DESCRIPTION
Fixes: #4 

Solution: Set the global_sepia value to 0 when the sepia checkbox gets unchecked.